### PR TITLE
Updated version of grunt-contrib-stylus dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "main.js",
   "dependencies": {
     "stylus": "~0.41.3",
-    "grunt-contrib-stylus": "~0.11.0"
+    "grunt-contrib-stylus": "~0.18.0"
   },
   "peerDependencies": {
     "lineman": ">= 0.19.0"


### PR DESCRIPTION
Was getting an error with version 0.11.0 of grunt-contrib-stylus:

```
Running "stylus:compile" (stylus) task
>> Destination not written because compiled files were empty.
Warning: Cannot read property 'dest' of undefined Use --force to continue.

Aborted due to warnings.
```

Version 0.18.0 seems to resolve the problem.
